### PR TITLE
wth - Email notifications at Creation of Record

### DIFF
--- a/app/assets/javascripts/pi_name_autocomplete.coffee
+++ b/app/assets/javascripts/pi_name_autocomplete.coffee
@@ -31,6 +31,7 @@ $ ->
           asyncResults(data)
 
     $('#research_master_pi_name').on 'typeahead:select', (ev, selection) ->
-      $('#research_master_department').val(selection.department)
+      $('#pi_name').val(selection.name)
+      $('#pi_email').val(selection.email)
 
 

--- a/app/controllers/research_masters_controller.rb
+++ b/app/controllers/research_masters_controller.rb
@@ -54,6 +54,16 @@ class ResearchMastersController < ApplicationController
     @research_master.user = current_user
     respond_to do |format|
       if @research_master.save
+        rm_pi = create_rm_pi(params[:pi_name],
+                             params[:pi_email],
+                             params[:pi_department],
+                             @research_master
+                            )
+        rm_notifier = ResearchMasterNotifier.new(rm_pi,
+                                                 @research_master.user.email,
+                                                 @research_master
+                                                )
+        rm_notifier.send_mail
         format.js
       else
         format.json { render json: { error: @research_master.errors }, status: 400 }
@@ -74,6 +84,17 @@ class ResearchMastersController < ApplicationController
   def find_rm_records
     @q = ResearchMaster.ransack(params[:q])
     @research_masters = @q.result(distinct: true)
+  end
+
+  def create_rm_pi(name, email, department, rm_id)
+    if name.present? && email.present?
+      ResearchMasterPi.create(
+        name: name,
+        email: email,
+        department: department,
+        research_master: rm_id
+      )
+    end
   end
 
   def research_master_params

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -1,0 +1,14 @@
+class Notifier < ActionMailer::Base
+
+  def success(recipient, rm_pi, rm_id)
+    @rm_pi = rm_pi || NullUser.new
+    @rm_id = rm_id
+    @url = ENV.fetch('RMID_LINK')
+    address = ENV.fetch('ENVIRONMENT') == 'staging' ? 'sparcrequest@gmail.com' : recipient
+    mail(
+      to: address,
+      subject: "Research Master Record Successfully Created (RMID: #{rm_id.id})",
+      from: 'no-reply@rmid.musc.edu'
+    )
+  end
+end

--- a/app/models/ldap_search.rb
+++ b/app/models/ldap_search.rb
@@ -17,6 +17,13 @@ class LdapSearch
     names
   end
 
+  def name_query(uid)
+    ldap = connect_to_ldap
+    ldap.search(:base => ldap.base, :filter => filter_query('uid', uid)) do |entry|
+      return entry[:cn].first
+    end
+  end
+
   private
 
   def connect_to_ldap

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -1,0 +1,11 @@
+class NullUser
+
+  def name
+    "Not Available"
+  end
+
+  def email
+    "Not Available"
+  end
+end
+

--- a/app/models/research_master.rb
+++ b/app/models/research_master.rb
@@ -1,6 +1,7 @@
 class ResearchMaster < ActiveRecord::Base
   belongs_to :user
   has_one :associated_record, dependent: :destroy
+  has_one :research_master_pi, dependent: :destroy
 
   validates :pi_name, :department, :long_title, :short_title, presence: true
   validates_length_of :long_title, maximum: 255
@@ -23,5 +24,4 @@ class ResearchMaster < ActiveRecord::Base
 
   accepts_nested_attributes_for :associated_record, allow_destroy: true,
     reject_if: proc { |att| att[:sparc_id].blank? && att[:eirb_id].blank? }
-
 end

--- a/app/models/research_master_notifier.rb
+++ b/app/models/research_master_notifier.rb
@@ -1,0 +1,45 @@
+class ResearchMasterNotifier
+
+  def initialize(rm_pi, owner_email, rm_id)
+    @rm_pi = rm_pi
+    @owner_email = owner_email || NullUser.new.email
+    @rm_id = rm_id
+  end
+
+  def send_mail
+    if @rm_pi.nil? || same_email
+      send_one
+    else
+      send_multiple
+    end
+  end
+
+  private
+
+  def send_one
+    Notifier.success(
+      @owner_email,
+      @rm_pi,
+      @rm_id
+    ).deliver_later
+  end
+
+  def send_multiple
+    recipients.each do |recipient|
+      Notifier.success(
+        recipient,
+        @rm_pi,
+        @rm_id
+      ).deliver_later
+    end
+  end
+
+  def same_email
+    @rm_pi.email == @owner_email
+  end
+
+  def recipients
+    [@rm_pi.email, @owner_email]
+  end
+end
+

--- a/app/models/research_master_pi.rb
+++ b/app/models/research_master_pi.rb
@@ -1,0 +1,8 @@
+class ResearchMasterPi < ActiveRecord::Base
+  belongs_to :research_master
+
+  validates :name, :email, presence: true
+
+  validates_format_of :email, with: /\A\S+@.+\.\S+\z/, on: :create,
+    allow_blank: true
+end

--- a/app/views/notifier/success.html.haml
+++ b/app/views/notifier/success.html.haml
@@ -1,0 +1,58 @@
+:css
+  table {
+      font-family: arial, sans-serif;
+      border-collapse: collapse;
+      width: 100%;
+  }
+
+  td, th {
+      border: 1px solid #dddddd;
+      text-align: left;
+      padding: 8px;
+  }
+
+%p
+  A research master record has been successfully created. Please review and/or
+  edit the record
+  = link_to 'here', @url, target: '_blank'
+  if needed.
+%table
+  %tr
+    %th
+      RMID
+    %th
+      = @rm_id.id
+  %tr
+    %th
+      PI Name
+    %th
+      = @rm_pi.name
+  %tr
+    %th
+      PI Department
+    %th
+      = @rm_id.department
+  %tr
+    %th
+      Short Title
+    %th
+      = @rm_id.short_title
+  %tr
+    %th
+      Long Title
+    %th
+      = @rm_id.long_title
+  %tr
+    %th
+      Funding Source
+    %th
+      = @rm_id.funding_source
+  %tr
+    %th
+      Creator
+    %th
+      = @rm_id.user.name
+%p
+  Please contact the SUCCESS Center at (843) 792-8300 or
+  = mail_to 'success@musc.edu'
+  with any questions you may have.

--- a/app/views/research_masters/_form.html.haml
+++ b/app/views/research_masters/_form.html.haml
@@ -1,4 +1,7 @@
 = form_for @research_master, html: { class: 'form-horizontal research-master-form' }, remote: true do |f|
+  = hidden_field_tag 'pi_name', nil
+  = hidden_field_tag 'pi_email', nil
+  = hidden_field_tag 'pi_department', nil
   .form-group
     = f.label :pi_name, t(:research_masters)[:new][:fields][:pi_name], class: 'col-sm-2 control-label', data: { toggle: 'tooltip', animation: 'false' }, title: t(:research_masters)[:new][:tooltips][:pi_name]
     .col-sm-10

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,8 @@ module ResearchMasterId
     config.active_record.raise_in_transactional_callbacks = true
     config.assets.paths << Rails.root.join('vendor', 'assets', 'components')
 
+    config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
+
     config.middleware.insert_before 0, "Rack::Cors" do
       allow do
         origins '*'

--- a/config/initializers/ldap_authenticatable.rb
+++ b/config/initializers/ldap_authenticatable.rb
@@ -16,7 +16,7 @@ module Devise
             admins = ENV.fetch('ADMINS').split(',')
             devs = ENV.fetch('DEVELOPERS').split(',')
             pwd = Devise.friendly_token
-            user = User.create_with(password: pwd, password_confirmation: pwd, admin: false).find_or_create_by(email: ldap_search.email_query(login))
+            user = User.create_with(password: pwd, password_confirmation: pwd, admin: false).find_or_create_by(email: ldap_search.email_query(login), name: ldap_search.name_query(login))
             if admins.any? { |word| login.include?(word) }
               user.update_attribute(:admin, true)
             end

--- a/db/migrate/20170203141029_create_research_master_pis_table.rb
+++ b/db/migrate/20170203141029_create_research_master_pis_table.rb
@@ -1,0 +1,10 @@
+class CreateResearchMasterPisTable < ActiveRecord::Migration
+  def change
+    create_table :research_master_pis do |t|
+      t.string :name
+      t.string :email
+      t.string :department
+      t.references :research_master, index: true, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20170203163205_add_name_to_users.rb
+++ b/db/migrate/20170203163205_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :name, :string, after: :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170123162923) do
+ActiveRecord::Schema.define(version: 20170203163205) do
 
   create_table "api_keys", force: :cascade do |t|
     t.string   "access_token", limit: 255
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20170123162923) do
 
   create_table "primary_pis", force: :cascade do |t|
     t.string   "name",        limit: 255
+    t.string   "email",       limit: 255
     t.string   "department",  limit: 255
     t.integer  "protocol_id", limit: 4
     t.datetime "created_at",              null: false
@@ -52,6 +53,15 @@ ActiveRecord::Schema.define(version: 20170123162923) do
     t.datetime "updated_at",                        null: false
   end
 
+  create_table "research_master_pis", force: :cascade do |t|
+    t.string  "name",               limit: 255
+    t.string  "email",              limit: 255
+    t.string  "department",         limit: 255
+    t.integer "research_master_id", limit: 4
+  end
+
+  add_index "research_master_pis", ["research_master_id"], name: "index_research_master_pis_on_research_master_id", using: :btree
+
   create_table "research_masters", force: :cascade do |t|
     t.string   "pi_name",        limit: 255
     t.string   "department",     limit: 255
@@ -67,6 +77,7 @@ ActiveRecord::Schema.define(version: 20170123162923) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255, default: "", null: false
+    t.string   "name",                   limit: 255
     t.boolean  "admin"
     t.boolean  "developer"
     t.string   "encrypted_password",     limit: 255, default: "", null: false
@@ -87,5 +98,6 @@ ActiveRecord::Schema.define(version: 20170123162923) do
 
   add_foreign_key "associated_records", "research_masters"
   add_foreign_key "primary_pis", "protocols"
+  add_foreign_key "research_master_pis", "research_masters"
   add_foreign_key "research_masters", "users"
 end

--- a/dotenv.example
+++ b/dotenv.example
@@ -3,3 +3,4 @@ EIRB_API=http://eirb_api
 ADMINS="sal20,lmf5,sih3,weh6,kyh201,bem24,kal200,sampsonr,wih205"
 DEVELOPERS="kyg200"
 RMID_LINK=https://rmid.musc.edu
+ENVIRONMENT='staging'

--- a/lib/mailer_previews/notifier_preview.rb
+++ b/lib/mailer_previews/notifier_preview.rb
@@ -1,0 +1,6 @@
+class NotifierPreview < ActionMailer::Preview
+
+  def success
+    Notifier.success(User.first.email, ResearchMasterPi.first, ResearchMaster.first)
+  end
+end

--- a/spec/controllers/research_masters_controller_spec.rb
+++ b/spec/controllers/research_masters_controller_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+describe ResearchMastersController, type: :controller do
+  describe '#create' do
+    it 'should create a RMID' do
+      user = create(:user)
+      sign_in user
+
+      expect { post :create, research_master: {
+        pi_name: 'William Holt',
+        department: 'department',
+        long_title: 'long title',
+        short_title: 'short',
+        funding_source: 'source',
+        user_id: user.id
+      }, format: :js,
+      pi_name: 'ooga',
+      pi_email: 'booga@booga.com'
+      }.to change(ResearchMaster, :count).by(1)
+    end
+
+    it 'should send two emails - one to owner and pi' do
+      user = create(:user)
+      sign_in user
+
+      expect { post :create, research_master: {
+        pi_name: 'William Holt',
+        department: 'department',
+        long_title: 'long title',
+        short_title: 'short',
+        funding_source: 'source',
+        user_id: user.id
+      },
+      format: :js,
+      pi_name: 'pi-man',
+      pi_email: 'primary-pi@gmail.com'
+      }.to change(ActionMailer::Base.deliveries, :count).by(2)
+    end
+
+    it 'should send one email if same email address' do
+      user = create(:user)
+      sign_in user
+
+      expect { post :create, research_master: {
+        pi_name: 'William Holt',
+        department: 'department',
+        long_title: 'long title',
+        short_title: 'short',
+        funding_source: 'source',
+        user_id: user.id
+      },
+      format: :js,
+      pi_name: 'William Holt',
+      pi_email: "#{user.email}"
+      }.to change(ActionMailer::Base.deliveries, :count).by(1)
+    end
+
+    it 'should create a RM PI' do
+      user = create(:user)
+      sign_in user
+
+      expect { post :create, research_master: {
+        pi_name: 'William Holt',
+        department: 'department',
+        long_title: 'long title',
+        short_title: 'short',
+        funding_source: 'source',
+        user_id: user.id
+      },
+      format: :js,
+      pi_name: 'pi man',
+      pi_email: 'pi-guy@pi.com'
+      }.to change(ResearchMasterPi, :count).by(1)
+    end
+
+    it 'should still send an email if RM PI is nil' do
+      user = create(:user)
+      sign_in user
+
+      expect { post :create, research_master: {
+        pi_name: 'William Holt',
+        department: 'department',
+        long_title: 'long title',
+        short_title: 'short',
+        funding_source: 'source',
+        user_id: user.id
+      },
+      format: :js,
+      pi_name: nil,
+      pi_email: nil
+      }.to change(ActionMailer::Base.deliveries, :count).by(1)
+    end
+
+    it 'should still create a RM object if RM PI nil' do
+      user = create(:user)
+      sign_in user
+
+      expect { post :create, research_master: {
+        pi_name: 'William Holt',
+        department: 'department',
+        long_title: 'long title',
+        short_title: 'short',
+        funding_source: 'source',
+        user_id: user.id
+      },
+      format: :js,
+      pi_name: nil,
+      pi_email: nil
+      }.to change(ResearchMaster, :count).by(1)
+    end
+
+  end
+end
+

--- a/spec/factories/primary_pis.rb
+++ b/spec/factories/primary_pis.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
+  sequence :pi_email do |n|
+    "person@#{n}@example.com"
+  end
   factory :primary_pi do
     name "MyString"
+    email :pi_email
     protocol nil
   end
 end

--- a/spec/factories/research_master_pi.rb
+++ b/spec/factories/research_master_pi.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :research_master_pi do
+    name 'String'
+    email 'email@email.com'
+    department 'dept'
+    research_master nil
+  end
+end

--- a/spec/factories/research_masters.rb
+++ b/spec/factories/research_masters.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
   factory :research_master do
     pi_name "MyString"
-department "MyString"
-long_title "MyString"
-short_title "MyString"
-funding_source "MyString"
-user nil
+    department "MyString"
+    long_title "MyString"
+    short_title "MyString"
+    funding_source "MyString"
+    user nil
   end
-
 end
+

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Notifier do
+
+  describe '#success' do
+
+    it 'should have two recipients' do
+      ENV['ENVIRONMENT'] = 'production'
+      owner = create(:user)
+      rm_id = create(:research_master, user: owner)
+      rm_pi = create(:research_master_pi, research_master: rm_id)
+
+      result = Notifier.success(owner.email, rm_pi, rm_id)
+
+      expect(result.to).to eq [owner.email]
+    end
+
+    it 'should have the correct subject' do
+      owner = create(:user)
+      rm_id = create(:research_master, user: owner)
+      rm_pi = create(:research_master_pi, research_master: rm_id)
+
+      result = Notifier.success(owner.email, rm_pi, rm_id)
+
+      expect(result.subject).to eq "Research Master Record Successfully Created (RMID: #{rm_id.id})"
+    end
+
+    it 'it should be from no-reply@rmid.musc.edu' do
+      owner = create(:user, email: 'pi@email.com')
+      rm_id = create(:research_master, user: owner)
+      rm_pi = create(:research_master_pi, research_master: rm_id)
+
+      result = Notifier.success(owner.email, rm_pi, rm_id)
+
+      expect(result.from).to eq ['no-reply@rmid.musc.edu']
+    end
+
+    it 'should send to gmail if env is staging' do
+      ENV['ENVIRONMENT'] = 'staging'
+      owner = create(:user, email: 'pi@email.com')
+      rm_id = create(:research_master, user: owner)
+      rm_pi = create(:research_master_pi, research_master: rm_id)
+
+      result = Notifier.success(owner.email, rm_pi, rm_id)
+
+      expect(result.to).to eq ['sparcrequest@gmail.com']
+    end
+
+    it 'carry on if production' do
+      ENV['ENVIRONMENT'] = 'production'
+      owner = create(:user, email: 'pi@email.com')
+      rm_id = create(:research_master, user: owner)
+      rm_pi = create(:research_master_pi, research_master: rm_id)
+
+      result = Notifier.success(owner.email, rm_pi, rm_id)
+
+      expect(result.to).to eq [owner.email]
+    end
+  end
+end
+

--- a/spec/models/ldap_search_spec.rb
+++ b/spec/models/ldap_search_spec.rb
@@ -61,5 +61,15 @@ describe LdapSearch do
       expect(result).to include ['Jerry Hardee', 'hardeeje@musc.edu']
     end
   end
+
+  describe '#name_query' do
+    it 'should return my name' do
+      ldap_search = LdapSearch.new
+
+      result = ldap_search.name_query('wih205')
+
+      expect(result).to eq 'William Holt'
+    end
+  end
 end
 

--- a/spec/models/null_user_spec.rb
+++ b/spec/models/null_user_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe NullUser do
+  describe '#name' do
+    it 'should return not available' do
+      null_user = NullUser.new
+
+      result = null_user.name
+
+      expect(result).to eq 'Not Available'
+    end
+  end
+
+  describe '#email' do
+    it 'should return not available' do
+      null_user = NullUser.new
+
+      result = null_user.email
+
+      expect(result).to eq 'Not Available'
+    end
+  end
+end
+

--- a/spec/models/research_master_notifier_spec.rb
+++ b/spec/models/research_master_notifier_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe ResearchMasterNotifier do
+  before { ActionMailer::Base.deliveries = [] }
+
+  describe '#send_mail' do
+    it 'should send only one email if the addresses are the same' do
+      user = create(:user)
+      rm_id = create(:research_master,
+                     pi_name: 'willy',
+                     department: 'dept',
+                     long_title: 'long',
+                     short_title: 'short',
+                     funding_source: 'funding',
+                     user: user)
+      owner_email = user.email
+      pi = create(:research_master_pi, email: user.email)
+      rm_notifier = ResearchMasterNotifier.new(pi, owner_email, rm_id)
+
+      rm_notifier.send_mail
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+    end
+
+    it 'should still send an email if rm_pi is nil' do
+      user = create(:user)
+      rm_id = create(:research_master,
+                     pi_name: 'willy',
+                     department: 'dept',
+                     long_title: 'long',
+                     short_title: 'short',
+                     funding_source: 'funding',
+                     user: user
+                    )
+      owner_email = user.email
+      rm_notifier = ResearchMasterNotifier.new(nil, owner_email, rm_id)
+
+      rm_notifier.send_mail
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+    end
+
+    it 'should still send an email if user email is nil' do
+      user = create(:user)
+      rm_id = create(:research_master,
+                     pi_name: 'willy',
+                     department: 'dept',
+                     long_title: 'long',
+                     short_title: 'short',
+                     funding_source: 'funding',
+                     user: user
+                    )
+      rm_notifier = ResearchMasterNotifier.new(nil, nil, rm_id)
+
+      rm_notifier.send_mail
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+    end
+
+    it 'should send two emails if different' do
+      user = create(:user)
+      rm_id = create(:research_master,
+                     pi_name: 'willy',
+                     department: 'dept',
+                     long_title: 'long',
+                     short_title: 'short',
+                     funding_source: 'funding',
+                     user: user)
+      owner_email = user.email
+      pi = create(:research_master_pi, research_master: rm_id)
+      rm_notifier = ResearchMasterNotifier.new(pi, owner_email, rm_id)
+
+      rm_notifier.send_mail
+
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+    end
+  end
+end

--- a/spec/models/research_master_pi_spec.rb
+++ b/spec/models/research_master_pi_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe ResearchMasterPi do
+
+  it { is_expected.to belong_to(:research_master) }
+
+  it { is_expected.to have_db_column(:name) }
+
+  it { is_expected.to have_db_column(:email) }
+
+  it { is_expected.to have_db_column(:department) }
+
+  it { is_expected.to have_db_column(:research_master_id) }
+
+  it { is_expected.to have_db_index(:research_master_id) }
+
+  it { is_expected.to validate_presence_of(:name) }
+
+  it { is_expected.to validate_presence_of(:email) }
+
+  it { is_expected.to allow_value('something@something.com').for(:email) }
+
+  it { is_expected.not_to allow_value('fljakdjflj').for(:email) }
+end

--- a/spec/models/research_master_spec.rb
+++ b/spec/models/research_master_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe ResearchMaster, type: :model do
 
   it { is_expected.to have_one(:associated_record) }
 
+  it { is_expected.to have_one(:research_master_pi) }
+
   it { is_expected.to validate_length_of(:long_title).is_at_most(255) }
   it { is_expected.to validate_length_of(:short_title).is_at_most(255) }
 


### PR DESCRIPTION
Send out an email to the creator and the PI (if they are the same
person, only send out 1 email) of a research master record when a RMID
is successfully created.[#138616777]