### PR TITLE
wth - funding source required

### DIFF
--- a/app/models/research_master.rb
+++ b/app/models/research_master.rb
@@ -3,7 +3,12 @@ class ResearchMaster < ActiveRecord::Base
   has_one :associated_record, dependent: :destroy
   has_one :research_master_pi, dependent: :destroy
 
-  validates :pi_name, :department, :long_title, :short_title, presence: true
+  validates :pi_name,
+    :department,
+    :long_title,
+    :short_title,
+    :funding_source,
+    presence: true
   validates_length_of :long_title, maximum: 255
   validates_length_of :short_title, maximum: 255
 

--- a/spec/features/user_must_specify_funding_source_spec.rb
+++ b/spec/features/user_must_specify_funding_source_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+feature 'User must specify funding source', js: true do
+  scenario 'successfully shows errors' do
+    create_and_sign_in_user
+
+    click_link 'Create Research Master ID'
+    fill_in 'research_master_pi_name', with: 'User'
+    fill_in 'research_master_department', with: 'Department'
+    fill_in 'research_master_long_title', with: 'Long'
+    fill_in 'research_master_short_title', with: 'short'
+
+    find('.submit-rm').click
+
+    expect(page).to have_content "Can't be blank"
+  end
+  scenario 'successfully does not show errors' do
+    create_and_sign_in_user
+
+    click_link 'Create Research Master ID'
+    fill_in 'research_master_pi_name', with: 'William Holt'
+    fill_in 'research_master_department', with: 'Department'
+    fill_in 'research_master_long_title', with: 'Long'
+    fill_in 'research_master_short_title', with: 'short'
+    choose 'research_master_funding_source_internal'
+
+    find('.submit-rm').click
+
+    expect(page).not_to have_content "Can't be blank"
+  end
+end
+

--- a/spec/models/research_master_spec.rb
+++ b/spec/models/research_master_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe ResearchMaster, type: :model do
   it { is_expected.to validate_length_of(:long_title).is_at_most(255) }
   it { is_expected.to validate_length_of(:short_title).is_at_most(255) }
 
+  it { is_expected.to validate_presence_of(:funding_source) }
+
   it 'should validate on uniqueness of pi_name, department and long title' do
     create(:research_master,
           pi_name: 'pi',


### PR DESCRIPTION
When creating a new research master record by clicking "Create Research
Master ID", I made the "Funding Source" a required field as well,
so that a user has to fill it out to be able to create a new
record.[#139305869]