### PR TITLE
wth - change 'About RMID' link

### DIFF
--- a/app/controllers/details_controller.rb
+++ b/app/controllers/details_controller.rb
@@ -1,8 +1,0 @@
-class DetailsController < ApplicationController
-  skip_before_action :authenticate_user!
-  protect_from_forgery except: :show
-
-  def show
-  end
-end
-

--- a/app/views/details/show.js.coffee
+++ b/app/views/details/show.js.coffee
@@ -1,1 +1,0 @@
-$("#about-modal").modal('show')

--- a/app/views/shared/_navbar.html.haml
+++ b/app/views/shared/_navbar.html.haml
@@ -4,7 +4,8 @@
       = link_to 'SPARC', 'http://sparc.musc.edu', class: 'navbar-brand', target: '_blank'
       = link_to 'eIRB', 'http://eirb.healthsciencessc.org', class: 'navbar-brand', target: '_blank'
       = link_to 'ePDS', 'http://erma.musc.edu/cgi-bin/grants_pi/admin/index.cgi', class: 'navbar-brand', target: '_blank'
-      = link_to 'About RMID', detail_path, class: 'navbar-brand', remote: true
+      = link_to 'About RMID', 'http://www.musc.edu/rmid',
+        class: 'navbar-brand', target: '_blank'
       %button{ class: 'navbar-toggle collapsed',
       data: { toggle: 'collapse', target: '#navbar' } }
         %span.sr-only Toggle navigation

--- a/spec/features/user_should_visit_new_page_after_click_about_rmid_spec.rb
+++ b/spec/features/user_should_visit_new_page_after_click_about_rmid_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+feature 'User should visit new page after clicking About RMID', js: true do
+  scenario 'successfully' do
+    create_and_sign_in_user
+    visit root_path
+
+    click_link 'About RMID'
+
+    page.driver.browser.window_focus page.windows.last.handle
+
+    expect(URI.parse(current_url).to_s).to eq 'https://www.musc.edu/rmid'
+  end
+end
+

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,3 +2,7 @@ require 'capybara/rails'
 require 'capybara/rspec'
 
 Capybara.javascript_driver = :webkit
+
+Capybara::Webkit.configure do |config|
+  config.allow_url("www.musc.edu")
+end


### PR DESCRIPTION
Removed the popup window of the "About RMID", and link that button
to an webpage (http://www.musc.edu/rmid) instead (by opening a new
browser tab).[#139309857]