### PR TITLE
wth - Fixed bug where modal wouldnt show if no associated records

### DIFF
--- a/app/controllers/research_masters_controller.rb
+++ b/app/controllers/research_masters_controller.rb
@@ -10,12 +10,14 @@ class ResearchMastersController < ApplicationController
 
   def show
     research_master = ResearchMaster.find(params[:id])
-    associated_record = research_master.associated_record
-    if associated_record.sparc_id?
-      @sparc_protocol = Protocol.find(associated_record.sparc_id)
-    end
-    if associated_record.eirb_id?
-      @eirb_protocol = Protocol.find(associated_record.eirb_id)
+    if research_master.associated_record.present?
+      associated_record = research_master.associated_record
+      if associated_record.sparc_id?
+        @sparc_protocol = Protocol.find(associated_record.sparc_id)
+      end
+      if associated_record.eirb_id?
+        @eirb_protocol = Protocol.find(associated_record.eirb_id)
+      end
     end
     respond_to do |format|
       format.js

--- a/spec/features/user_should_see_no_association_if_nothing_exists_spec.rb
+++ b/spec/features/user_should_see_no_association_if_nothing_exists_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+feature 'User should see no association if nothing exists', js: true do
+  scenario 'successfully' do
+    create(:research_master)
+    create_and_sign_in_user
+
+    first('.research-master').click
+
+    expect(page).to have_css 'h1.text-center', text: 'No Associated Protocols'
+  end
+
+  scenario 'successfully' do
+    rm = create(:research_master)
+    sparc_protocol = create(:protocol, type: 'SPARC')
+    eirb_protocol = create(:protocol, type: 'EIRB')
+    primary_pi = create(:primary_pi, protocol: sparc_protocol)
+    primary_pi = create(:primary_pi, protocol: eirb_protocol)
+    create(:associated_record, research_master: rm, sparc_id: sparc_protocol.id, eirb_id: eirb_protocol.id)
+    create_and_sign_in_user
+
+    first('.research-master').click
+
+    expect(page).to have_content sparc_protocol.long_title
+    expect(page).to have_content eirb_protocol.long_title
+  end
+
+end


### PR DESCRIPTION
Clicking a RM record with no Associated Records would trigger an
internal server error, yet now it would correctly display that this
record has 'No Associated Protocols'. [#139598277]