### PR TITLE
wth - (RMID) Change eIRB Verification Criteria

### DIFF
--- a/lib/tasks/update_data.rake
+++ b/lib/tasks/update_data.rake
@@ -106,7 +106,7 @@ task update_data: :environment do
       end
     end
     unless study['research_master_id'].nil?
-      validated_states = ['Acknowledged', 'Approved', 'Completed', 'Disapproved', 'Exempt Approved', 'Expired',  'Expired - Continuation in Progress', 'External IRB Review Archive', 'Not Human Subjects Research', 'Suspended', 'Terminated', 'Withdrawn']
+      validated_states = ['Acknowledged', 'Approved', 'Completed', 'Disapproved', 'Exempt Approved', 'Expired',  'Expired - Continuation in Progress', 'External IRB Review Archive', 'Not Human Subjects Research', 'Suspended', 'Terminated']
       rm = ResearchMaster.find_by(id: study['research_master_id'])
       unless rm.nil?
         if Protocol.where(eirb_id: study['pro_number'], type: 'EIRB').present?


### PR DESCRIPTION
Please change the verification criteria for eIRB verification (for
updating RM record long and short title) and delete the "Withdrawn"
state from the criteria (validated_states).

Background info: withdrawn studies in eIRB is not desired to be tracked
and not maintained any more, and we don't want RMID records to be
updating according to it. When it comes back for a re-submission, it
would change to another state and then be updated.

[#146791593]

Story - (https://www.pivotaltracker.com/story/show/146791593)