### PR TITLE
wth - (SPARC/RMID API) Handling Deleted RMID Record

### DIFF
--- a/app/controllers/research_masters_controller.rb
+++ b/app/controllers/research_masters_controller.rb
@@ -73,6 +73,11 @@ class ResearchMastersController < ApplicationController
   def destroy
     @research_master = ResearchMaster.find(params[:id])
     authorize! :destroy, @research_master
+    if @research_master.sparc_protocol_id
+      HTTParty.patch(
+        "#{ENV.fetch('SPARC_URL')}/protocols/#{Protocol.find(@research_master.sparc_protocol_id).sparc_id}/research_master?access_token=#{ApiKey.first.access_token}"
+      )
+    end
     @research_master.destroy
   end
 

--- a/app/models/research_master.rb
+++ b/app/models/research_master.rb
@@ -3,6 +3,7 @@ class ResearchMaster < ApplicationRecord
   belongs_to :pi, class_name: "User"
   has_many :research_master_coeus_relations
   has_many :protocols, through: :research_master_coeus_relations
+  has_many :research_master_pis, dependent: :destroy
   paginates_per 50
 
 


### PR DESCRIPTION
Background: When a RMID is used by a SPARC protocol, that SPARC protocol is associated with the RMID, with short title and long title pulled from RMID record, and pro# pulled from the associated eIRB record (if it exists). However, when the RMID record is deleted, currently it's failing the API, because the long title, short title, pro# on the SPARC protocol will be updated to blank. Ideally, the user should update the RMID in SPARC, but this scenario should be taken into consideration.

Please change the API rules, so that when the RMID a SPARC protocol uses doesn't exist any more, remove the RMID in SPARC database when API refreshes, but keep the long title, short title, and pro#.

Acceptance criteria:
1). When a user deletes a RMID that already has associated SPARC record, no fatal error happens;
2). The current long title, short title, and pro# should be kept;
3). This method should be tied with RMID configuration for turning on/off.

[#151617565]

Story - https://www.pivotaltracker.com/story/show/151617565