### PR TITLE
wth - (RMID) Remove research_master_pis Table

### DIFF
--- a/db/migrate/20180116172547_drop_research_master_pis_table.rb
+++ b/db/migrate/20180116172547_drop_research_master_pis_table.rb
@@ -1,0 +1,5 @@
+class DropResearchMasterPisTable < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :research_master_pis
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180112135337) do
+ActiveRecord::Schema.define(version: 20180116172547) do
 
   create_table "api_keys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "access_token"
@@ -83,14 +83,6 @@ ActiveRecord::Schema.define(version: 20180112135337) do
     t.index ["research_master_id"], name: "index_research_master_coeus_relations_on_research_master_id"
   end
 
-  create_table "research_master_pis", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
-    t.string "email"
-    t.string "department"
-    t.integer "research_master_id"
-    t.index ["research_master_id"], name: "index_research_master_pis_on_research_master_id"
-  end
-
   create_table "research_masters", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "pi_name"
     t.string "department"
@@ -134,7 +126,6 @@ ActiveRecord::Schema.define(version: 20180112135337) do
 
   add_foreign_key "primary_pis", "departments"
   add_foreign_key "primary_pis", "protocols"
-  add_foreign_key "research_master_pis", "research_masters"
   add_foreign_key "research_masters", "users", column: "creator_id"
   add_foreign_key "research_masters", "users", column: "pi_id"
 end


### PR DESCRIPTION
Please remove the research_master_pis table from staging and production sites, since we have moved the relation into research_masters.pi_id and users.

[#153759080]

Story - https://www.pivotaltracker.com/story/show/153759080