### PR TITLE
ml-test_emails_should_show_receiver_address

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -7,7 +7,7 @@ class Notifier < ActionMailer::Base
     address = ENV.fetch('ENVIRONMENT') == 'staging' ? 'sparcrequest@gmail.com' : recipient
     mail(
       to: address,
-      subject: "Research Master Record Successfully Created (RMID: #{rm_id.id} - #{recipient.email})"
+      subject: "Research Master Record Successfully Created (RMID: #{rm_id.id} - #{recipient.email})",
       from: 'donotreply@musc.edu'
     )
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/153062359

In RMID testing environment, all the emails are sent to the gmail address, but there is currently no way to tell which email address(es) are the emails intended to be sent to.

Please add the receiver's email address into the subject line of the email (or other appropriate place) for testing purposes. 