### PR TITLE
wth - (RMID) Tie Button Display/Disable to User Rights

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,10 +3,11 @@ class Ability
 
   def initialize(user)
     if user.admin?
-      can :manage, :all
+      can :update, ResearchMaster, eirb_validated: false
+      can :destroy, ResearchMaster
     end
 
-    can :update, ResearchMaster, creator_id: user.id
+    can :update, ResearchMaster, creator_id: user.id, eirb_validated: false
 
     can :destroy, ResearchMaster, eirb_validated: false, creator_id: user.id
 


### PR DESCRIPTION
As found out while testing a previous feature (https://www.pivotaltracker.com/story/show/149809033), admin users can still Edit the eIRB verified records by remove the "disabled" property in console and then click "Edit", because the button display is processed in the view instead of in the user method.

Please combine the 2 pieces of logic, so that even admins won't be able to edit a verified record.

[#152858556]

Story - https://www.pivotaltracker.com/story/show/152858556