### PR TITLE
wth - (RMID) Protocol Update Method Logic Fine-Tunex

### DIFF
--- a/lib/tasks/update_data.rake
+++ b/lib/tasks/update_data.rake
@@ -87,6 +87,12 @@ task update_data: :environment do
     else
       existing_protocol = Protocol.find_by(sparc_id: protocol['id'])
       existing_protocol.update_attribute(:short_title, protocol['short_title'])
+      existing_protocol.update_attribute(:long_title, protocol['title'])
+      unless existing_protocol.primary_pi.nil?
+        existing_protocol.primary_pi.update_attribute(:first_name, protocol['first_name'])
+        existing_protocol.primary_pi.update_attribute(:last_name, protocol['last_name'])
+        existing_protocol.primary_pi.update_attribute(:department, Department.find_or_create_by(name: protocol['pi_department'].nil? ? 'N/A' : protocol['pi_department']))
+      end
     end
     unless protocol['research_master_id'].nil?
       rm = ResearchMaster.find_by(id: protocol['research_master_id'])


### PR DESCRIPTION
Background: we have seen dozens of cases so far for which the PI name shown for protocols in RMID backend is different from the current PI name shown in SPARC or eIRB.

Please double-check the protocol update method, so that it compares every protocol-level field and then determines whether it is updating the protocol record.

[#154807847]

Story - https://www.pivotaltracker.com/story/show/154807847