### PR TITLE
wth - (RMID) Add Notification Button and Message Box for Admin Users

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,28 @@
+class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @research_master = ResearchMaster.find(params[:research_master_id])
+    @notification = Notification.new
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  def create
+    @research_master = ResearchMaster.find(params[:research_master_id])
+    @notification = Notification.new(notification_params)
+    if @notification.valid?
+      AdminNotificationJob.perform_later(@research_master, @notification.message, current_user)
+    end
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  private
+
+  def notification_params
+    params.require(:notification).permit(:message)
+  end
+end

--- a/app/jobs/admin_notification_job.rb
+++ b/app/jobs/admin_notification_job.rb
@@ -1,0 +1,8 @@
+class AdminNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(research_master_id, message, admin)
+    email = AdminNotification.new(research_master_id, message, admin)
+    email.admin_notifier
+  end
+end

--- a/app/mailers/admin_notification.rb
+++ b/app/mailers/admin_notification.rb
@@ -1,0 +1,12 @@
+class AdminNotification < ActionMailer::Base
+
+  def admin_notifier(research_master_id, message, admin)
+    @message = message
+    @research_master_id = research_master_id
+    mail(
+      to: ENV.fetch('ENVIRONMENT') == 'staging' ? 'sparcrequest@gmail.com' : [research_master_id.creator.email, research_master_id.pi.nil? ? '' : research_master_id.pi.email],
+      subject: "Research Master ID #{rm_id.id} - Message from Admin",
+      from: admin
+    )
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,20 @@
+class Notification
+  include ActiveModel::Validations
+  include ActiveModel::Conversion
+  extend ActiveModel::Naming
+
+  attr_accessor :message
+
+  validates :message, presence: true
+
+  def initialize(attributes = {})
+    attributes.each do |name, value|
+      send("#{name}=", value)
+    end
+  end
+
+  def persisted?
+    false
+  end
+end
+

--- a/app/views/admin_notification/admin_notifier.html.haml
+++ b/app/views/admin_notification/admin_notifier.html.haml
@@ -1,0 +1,10 @@
+%p
+  = "Dear #{@research_master_id.creator.email}, #{@research_master_id.pi.nil? ? '' : @research_master_id.pi.email}
+%p
+  You have received a message from a Research Master ID admin. You can view the message below.
+%p
+  = @message
+%p
+  Please contact the SUCCESS Center at (843) 792-8300 or
+  = mail_to 'success@musc.edu'
+  with any questions you may have.

--- a/app/views/admin_notification/admin_notifier.text.haml
+++ b/app/views/admin_notification/admin_notifier.text.haml
@@ -1,0 +1,10 @@
+%p
+  = "Dear #{@research_master_id.creator.email}, #{@research_master_id.pi.nil? ? '' : @research_master_id.pi.email}
+%p
+  You have received a message from a Research Master ID admin. You can view the message below.
+%p
+  = @message
+%p
+  Please contact the SUCCESS Center at (843) 792-8300 or
+  = mail_to 'success@musc.edu'
+  with any questions you may have.

--- a/app/views/notifications/_form.html.haml
+++ b/app/views/notifications/_form.html.haml
@@ -1,0 +1,26 @@
+= form_for @notification, html: { class: 'form-horizontal' }, remote: true do |f|
+  = hidden_field_tag 'research_master_id', research_master.id
+  .modal-content
+    .modal-header
+      %button{ class: 'close', data: { dismiss: 'modal' } }
+        %span
+          &times;
+      %h4.modal-title
+        Send Notification
+    .modal-body
+      .form-group
+        = label_tag 'from', 'From', class: 'col-xs-2'
+        .col-xs-10
+          = text_field_tag 'from', current_user.email, class: 'form-control', disabled: true
+      .form-group
+        = label_tag 'to', 'To', class: 'col-xs-2'
+        .col-xs-10
+          = text_field_tag 'to', "#{research_master.creator.email}, #{research_master.pi.nil? ? '' : research_master.pi.email}", class: 'form-control', disabled: true
+      .form-group
+        = f.label :message, 'Message*', class: 'col-xs-2'
+        .col-xs-10
+          = f.text_area :message, class: 'form-control'
+    .modal-footer
+      %button{ class: 'btn btn-default', data: { dismiss: 'modal' } }
+        Close
+      = f.submit 'Send Message', class: 'btn btn-primary notification-button'

--- a/app/views/notifications/create.js.coffee
+++ b/app/views/notifications/create.js.coffee
@@ -1,0 +1,6 @@
+<% if @notification.valid? %>
+$('#newResearchMasterModal').modal('hide')
+swal('Success', 'Your message has been sent', 'success')
+<% else %>
+swal('Error', 'Your message could not be sent', 'error')
+<% end %>

--- a/app/views/notifications/new.js.coffee
+++ b/app/views/notifications/new.js.coffee
@@ -1,0 +1,3 @@
+$('#newResearchMasterModal').modal('show')
+$('.notification-button').prop('disabled', 'true')
+$('#newResearchMasterModal .modal-dialog').html("<%= j render 'form', research_master: @research_master %>")

--- a/app/views/research_masters/_research_master_index_table.html.haml
+++ b/app/views/research_masters/_research_master_index_table.html.haml
@@ -24,6 +24,10 @@
       = research_master.funding_source
     %td.research-master{ data: { id: research_master.id } }
       = display_research_type(research_master.research_type)
+    - if current_user.admin?
+      %td
+        = link_to new_notifications_path(research_master_id: research_master.id), class: 'btn btn-info', remote: true do
+          %span.glyphicon.glyphicon-envelope
     %td
       = link_to edit_research_master_path(research_master), class: [("btn btn-warning edit-#{research_master.id}"), ('disabled' unless research_master.creator_id == current_user.id || current_user.admin?), ('disabled' if research_master.eirb_validated?)], remote: true do
         %span.glyphicon.glyphicon-edit

--- a/app/views/research_masters/index.html.haml
+++ b/app/views/research_masters/index.html.haml
@@ -82,6 +82,9 @@
         = sort_link(@q, :funding_source, 'Funding Source')
       %th
         = sort_link(@q, :research_type, 'Research Type')
+      - if current_user.admin?
+        %th
+          Notification
       %th
         Edit
       %th

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   resources :research_masters
 
+  resource :notifications
+
   resource :detail, only: [:show]
 
   get "test_exception_notifier" => "application#test_exception_notifier"


### PR DESCRIPTION
On the RMID homepage, for each RMID record, please add a "Notification" button for admin users, which
1). shows the Requester user and PI user as default Email recipient and logged-in admin user as default Sender, and
2). allow the admin user to type in the message to be emailed to the users.

Note: This is requested a function to cope with the "orphaned" RMID record that has  been existed for a while but with no association to any of the systems.

[#155592680]