### PR TITLE
wth - (RMID) RMID PI Updated Caused by Validated eIRB Records Should …

### DIFF
--- a/app/views/pi_mailer/notify_pis.html.haml
+++ b/app/views/pi_mailer/notify_pis.html.haml
@@ -1,6 +1,4 @@
 %p
-  = "Dear #{@current_pi.name}"
-%p
   = "Dear #{@existing_pi.name} & #{@current_pi.name}"
 %p
   The Primary PI of the Research Master ID record has been updated. Please see below the detailed information.


### PR DESCRIPTION
…Send Email

Following a previous story: (https://www.pivotaltracker.com/story/show/154809566), when the RMID PI is updated because its associated eIRB records is verified and with updated (different) PI, please send out email notifications to the previous PI, and the new PI about the update.

Below is the example email format for reference
Subject: RMID xxxx PI Change
Content: Dear xxx, xxx,
This message is to notify that Research Master record (RMIDS: xxxx, Short Title: xxxx) has a PI update, caused by the associated eIRB record.

(table content)
RMID,  Creator, Previous PI, Updated PI, eIRB Record

Please contact the SUCCESS Center at (843) 792-8300 or success@musc.edu with any questions you may have.

[#157324723]

Story - https://www.pivotaltracker.com/story/show/157324723