### PR TITLE
(RMID) Change API Data Refresh Schedule

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,3 @@
-every 4.hours, :roles => [:app] do
+every 1.day, at: ['2:30 am', '6:30 am', '10:30 am', '2:30 pm', '6:30 pm', '10:30 pm'], :roles => [:app] do
   rake 'update_data'
 end


### PR DESCRIPTION
Background: eIRB imaging site creates the snapshot data every 4 hours from 1:30am, 5:30am, etc.

In order to shorten the time in-between the RMID data refresh and the eIRB one, so that the updates made in eIRB system is reflected more timingly, we should change the RMID refresh schedule to 2:30am 6:30am 10:30am 2:30pm 6:30pm 10:30pm instead.