### PR TITLE
wth - (RMID) Adding COEUS Project ID into protocols

### DIFF
--- a/db/migrate/20180723173135_add_coues_project_id_to_protocols.rb
+++ b/db/migrate/20180723173135_add_coues_project_id_to_protocols.rb
@@ -1,0 +1,5 @@
+class AddCouesProjectIdToProtocols < ActiveRecord::Migration[5.1]
+  def change
+    add_column :protocols, :coeus_project_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180507150154) do
+ActiveRecord::Schema.define(version: 20180723173135) do
 
   create_table "api_keys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "access_token"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 20180507150154) do
     t.string "coeus_protocol_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "coeus_project_id"
   end
 
   create_table "research_master_coeus_relations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -103,14 +104,6 @@ ActiveRecord::Schema.define(version: 20180507150154) do
     t.datetime "updated_at", null: false
     t.index ["protocol_id"], name: "index_research_master_coeus_relations_on_protocol_id"
     t.index ["research_master_id"], name: "index_research_master_coeus_relations_on_research_master_id"
-  end
-
-  create_table "research_master_pis", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
-    t.string "email"
-    t.string "department"
-    t.integer "research_master_id"
-    t.index ["research_master_id"], name: "index_research_master_pis_on_research_master_id"
   end
 
   create_table "research_masters", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -155,7 +148,6 @@ ActiveRecord::Schema.define(version: 20180507150154) do
 
   add_foreign_key "primary_pis", "departments"
   add_foreign_key "primary_pis", "protocols"
-  add_foreign_key "research_master_pis", "research_masters"
   add_foreign_key "research_masters", "users", column: "creator_id"
   add_foreign_key "research_masters", "users", column: "pi_id"
 end

--- a/lib/tasks/update_data.rake
+++ b/lib/tasks/update_data.rake
@@ -225,7 +225,8 @@ task update_data: :environment do
         mit_award_number: ad['mit_award_number'],
         sequence_number: ad['sequence_number'],
         title: ad['title'],
-        entity_award_number: ad['entity_award_number']
+        entity_award_number: ad['entity_award_number'],
+        coeus_project_id: ad['coeus_project_id']
       )
     end
     if ResearchMaster.exists?(ad['rmid'])


### PR DESCRIPTION
As a prep work for a SPARCRequest new feature: https://www.pivotaltracker.com/story/show/157642975, we need to bring in COEUS project ID (SRC_ORSP_AWARD_DETAILS.ACCOUNT NUMBER) into the protocols table, as one of the fields usable for RMID/SPARC API.

[#157644998]

Story - https://www.pivotaltracker.com/story/show/157644998