### PR TITLE
KG - Sanitized Data Gem Link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,4 +57,4 @@ group :test do
 end
 
 ### custom gem for data sanitization ###
-gem 'sanitized_data',  git: 'git@github.com:HSSC/sanitized_data.git'
+gem 'sanitized_data',  git: 'https://github.com/HSSC/sanitized_data.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:HSSC/sanitized_data.git
+  remote: https://github.com/HSSC/sanitized_data.git
   revision: 2fde04e1cb3bf61ff6109bb712984bf2fce4bd23
   specs:
     sanitized_data (0.0.3)


### PR DESCRIPTION
The source for the `sanitized_data` gem fails to load when running `bundle install`. Changing it to this URL fixes the issue.