### PR TITLE
KG - Add API::ProtocolsController

### DIFF
--- a/app/controllers/api/protocols_controller.rb
+++ b/app/controllers/api/protocols_controller.rb
@@ -1,0 +1,13 @@
+class Api::ProtocolsController < ApplicationController
+  def index
+    respond_to do |format|
+      format.json {
+        if params[:type] && ['SPARC', 'EIRB', 'COEUS'].include?(params[:type])
+          render json: Protocol.where(type: params[:type]).to_json
+        else
+          render json: Protocool.all.to_json
+        end
+      }
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,8 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  before_action :authenticate_user!
+
+  before_action :authenticate_user!, unless: -> { request.path_parameters[:controller].include?("api") }
 
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :research_masters, only: [:index, :show]
     resources :validated_records, only: [:index]
+    resources :protocols, only: [:index]
     resources :api_keys, only: [:create, :new]
   end
 


### PR DESCRIPTION
This controller is needed for SPARC to import eIRB data by directly matching with eIRB protocol `eirb_id`s