### PR TITLE
KG - Fix PI Name Search

### DIFF
--- a/db/migrate/20190312175634_adding_attributes_to_users_table.rb
+++ b/db/migrate/20190312175634_adding_attributes_to_users_table.rb
@@ -17,7 +17,12 @@ class AddingAttributesToUsersTable < ActiveRecord::Migration[5.1]
         bad_results << user.id
       else
         user_data = results.first
-        user.update_attributes(first_name: user_data[:first_name], last_name: user_data[:last_name], middle_initial: user_data[:middle_initial], pvid: user_data[:pvid])
+        user.update_attributes(
+          name: user_data[:name],
+          first_name: user_data[:first_name],
+          last_name: user_data[:last_name],
+          middle_initial: user_data[:middle_initial],
+          pvid: user_data[:pvid])
       end
     end
 
@@ -30,9 +35,6 @@ class AddingAttributesToUsersTable < ActiveRecord::Migration[5.1]
     puts "#"*50
     puts "#"*50
     puts "#"*50
-
-
-
   end
 
   def down


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164864531

With the recent LDAP changes in the 1.3.0 release, LDAP now returns `name` as `first mi last`. However very few `users` records have this format. Historically we have used `first last`, not `first mi last`. This means that when the search happens, it looks for `first mi last`. This migration needs to be re-run to include the `name` attribute.