### PR TITLE
rake task to clean up users without pvid and rmids

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: [:shibboleth]
 
   has_many :deleted_rmids
+  has_many :protocols, foreign_key: :primary_pi_id
 
   attr_accessor :login
 

--- a/lib/tasks/remove_pvidless_rmidless_users_and_protocols.rake
+++ b/lib/tasks/remove_pvidless_rmidless_users_and_protocols.rake
@@ -1,0 +1,36 @@
+# Copyright © 2016 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+task :remove_pvidless_rmidless_users_and_protocols => :environment do
+  users = User.where(pvid: nil)
+
+  puts "Number of users to check: #{users.count}"
+
+  users.each do |user|
+    if user.research_masters.present?
+      puts "Skipping ID:#{user.id} Email: #{user.email} Netid: #{user.net_id} because they have RMID records (#{user.research_masters.map(&:id)})"
+    else
+      puts "Removing data for ID:#{user.id} Email: #{user.email} Netid: #{user.net_id} (protocols count #{user.protocols.count})"
+      user.protocols.destroy
+      user.destroy
+    end
+  end
+
+end


### PR DESCRIPTION
Grab all users with no PVID, check if they have research master records, delete user and protocols if not