### PR TITLE
RMID-330: Expose eirb_state in api

### DIFF
--- a/app/views/api/research_masters/show.json.jbuilder
+++ b/app/views/api/research_masters/show.json.jbuilder
@@ -4,6 +4,7 @@ json.long_title               @research_master.long_title
 json.coeus_project_numbers    @research_master.coeus_protocols.try(:pluck, :coeus_project_id).try(:compact)
 json.eirb_validated           @research_master.eirb_validated
 json.eirb_pro_number          @research_master.eirb_protocol.try(:eirb_id)
+json.eirb_state               @research_master.eirb_protocol.try(:eirb_state)
 json.date_initially_approved  @research_master.eirb_protocol.try(:date_initially_approved).try(:strftime, "%m/%d/%Y")
 json.date_approved            @research_master.eirb_protocol.try(:date_approved).try(:strftime, "%m/%d/%Y")
 json.date_expiration          @research_master.eirb_protocol.try(:date_expiration).try(:strftime, "%m/%d/%Y")

--- a/app/views/api/validated_records/index.json.jbuilder
+++ b/app/views/api/validated_records/index.json.jbuilder
@@ -5,6 +5,7 @@ json.array! @validated_research_masters do |rm|
   json.coeus_project_numbers    rm.coeus_protocols.try(:pluck, :coeus_project_id).try(:compact)
   json.eirb_validated           rm.eirb_validated
   json.eirb_pro_number          rm.eirb_protocol.try(:eirb_id)
+  json.eirb_state               rm.eirb_protocol.try(:eirb_state)
   json.date_initially_approved  rm.eirb_protocol.try(:date_initially_approved)
   json.date_approved            rm.eirb_protocol.try(:date_approved)
   json.date_expiration          rm.eirb_protocol.try(:date_expiration)


### PR DESCRIPTION
For sposdev-1359 story, we need to use eirb_state in sparc app to decide if irb date fields should be readonly